### PR TITLE
Add LapTimer utility for race timing

### DIFF
--- a/src/core/LapTimer.ts
+++ b/src/core/LapTimer.ts
@@ -38,7 +38,7 @@ export class LapTimer {
   recordSector(): number | null {
     if (!this.isRunning) return null;
     
-    const sectorTime = Date.now() - this.currentLapStart - this.getTotalSectorTime();
+    const sectorTime = Math.max(0, Date.now() - this.currentLapStart - this.getTotalSectorTime());
     this.sectorTimes.push(sectorTime);
     return sectorTime;
   }
@@ -64,7 +64,7 @@ export class LapTimer {
       sector2: this.sectorTimes[1] ?? null,
       sector3: this.sectorTimes[2] ?? null,
       isValid: lapIsValid,
-      timestamp: new Date()
+      timestamp: new Date(this.currentLapStart)
     };
 
     this.laps.push(lap);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,4 +2,5 @@ export { EventBus } from './EventBus';
 export { StateManager } from './StateManager';
 export { PluginManager } from './PluginManager';
 export { Game } from './Game';
+export { LapTimer } from './LapTimer';
 export * from './types';

--- a/tests/LapTimer.test.ts
+++ b/tests/LapTimer.test.ts
@@ -68,15 +68,25 @@ describe('LapTimer', () => {
     });
 
     it('should record sector times in lap', () => {
+      const mockNow = vi.spyOn(Date, 'now');
+      let time = 0;
+      mockNow.mockImplementation(() => time);
+
+      time = 0;
       timer.startLap();
+      time = 30000;
       timer.recordSector();
+      time = 60000;
       timer.recordSector();
+      time = 90000;
       timer.recordSector();
       const lap = timer.completeLap();
       
-      expect(lap?.sector1).not.toBeNull();
-      expect(lap?.sector2).not.toBeNull();
-      expect(lap?.sector3).not.toBeNull();
+      expect(lap?.sector1).toBe(30000);
+      expect(lap?.sector2).toBe(30000);
+      expect(lap?.sector3).toBe(30000);
+
+      mockNow.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a new `LapTimer` class to track lap times during race sessions.

## Changes

- **LapTimer.ts**: Core timing utility with:
  - Lap time tracking with sector breakdown (S1, S2, S3)
  - Fastest lap calculation
  - Average lap time calculation
  - Time formatting (MM:SS.mmm)
  - Valid/invalid lap marking

- **LapTimer.test.ts**: Unit tests covering:
  - Time formatting
  - Lap recording
  - Statistics calculation
  - Reset functionality

## Usage

```typescript
const timer = new LapTimer();
timer.startLap();
timer.recordSector(); // S1
timer.recordSector(); // S2
timer.recordSector(); // S3
const lap = timer.completeLap();

console.log(LapTimer.formatTime(lap.time)); // "1:23.456"
```

## Testing

Run `npm test` to execute the unit tests.