### PR TITLE
Physics improvements: car collisions, faster speeds, wider tracks

### DIFF
--- a/data/tracks/bergheim.json
+++ b/data/tracks/bergheim.json
@@ -4,7 +4,7 @@
   "country": "Austria",
   "lengthMeters": 6840,
   "raceLaps": 44,
-  "trackWidth": 60,
+  "trackWidth": 90,
   "characteristics": "Technical circuit with flowing corners through forested hills. Inspired by Spa and Suzuka - elevation changes, flowing esses, and demanding for driver and car.",
   "averageLapTime": 105,
   "startFinish": {

--- a/data/tracks/porto-azzurro.json
+++ b/data/tracks/porto-azzurro.json
@@ -4,7 +4,7 @@
   "country": "Italy",
   "lengthMeters": 3340,
   "raceLaps": 78,
-  "trackWidth": 55,
+  "trackWidth": 70,
   "characteristics": "Tight street circuit with narrow sections, barriers close to track, minimal runoff. Inspired by Monaco - precision and concentration required.",
   "averageLapTime": 75,
   "startFinish": {

--- a/data/tracks/velocita.json
+++ b/data/tracks/velocita.json
@@ -4,7 +4,7 @@
   "country": "Italy",
   "lengthMeters": 5793,
   "raceLaps": 53,
-  "trackWidth": 70,
+  "trackWidth": 100,
   "characteristics": "High-speed temple of racing with long straights and famous chicanes. Inspired by Monza - slipstreaming duels and low downforce setups.",
   "averageLapTime": 81,
   "startFinish": {

--- a/src/physics/PhysicsPlugin.ts
+++ b/src/physics/PhysicsPlugin.ts
@@ -2,7 +2,7 @@ import type { Plugin, GameContext } from '@core/types';
 import type { CarState, CarConfig } from './types';
 import type { Point } from '@tracks/types';
 import { createCarState, DEFAULT_CAR_CONFIG } from './types';
-import { updateCarPhysics, constrainToTrackByDistance } from './CarPhysics';
+import { updateCarPhysics, constrainToTrackByDistance, resolveAllCarCollisions } from './CarPhysics';
 import type { InputState } from '@input/types';
 import { DEFAULT_INPUT_STATE } from '@input/types';
 
@@ -64,6 +64,11 @@ export class PhysicsPlugin implements Plugin {
       }
       
       this.cars.set(carId, newState);
+    }
+
+    // Resolve car-to-car collisions
+    if (this.cars.size > 1) {
+      resolveAllCarCollisions(this.cars, this.carConfigs, DEFAULT_CAR_CONFIG);
     }
 
     // Store player car state in game state for other systems

--- a/src/physics/types.ts
+++ b/src/physics/types.ts
@@ -67,20 +67,26 @@ export interface CarConfig {
   driftThreshold: number;
   /** How quickly the car slides when drifting */
   driftFactor: number;
+  /** Car length (front to back) for collision */
+  length: number;
+  /** Car width (side to side) for collision */
+  width: number;
 }
 
 /** Default arcade-style car configuration */
 export const DEFAULT_CAR_CONFIG: CarConfig = {
-  maxSpeed: 180,           // Reasonable top speed
-  acceleration: 120,       // Moderate acceleration
-  braking: 200,            // Strong brakes
-  drag: 30,                // Gentle slowdown when coasting
-  turnSpeed: 3.0,          // Responsive turning
-  turnSpeedFalloff: 0.4,   // Turning gets harder at high speed
+  maxSpeed: 360,           // 2x speed for faster racing
+  acceleration: 240,       // 2x acceleration to match
+  braking: 400,            // 2x braking to match
+  drag: 60,                // 2x drag to match
+  turnSpeed: 4.5,          // Faster turning for high speed (was 3.0)
+  turnSpeedFalloff: 0.2,   // Steering stays responsive at speed (was 0.4)
   minTurnSpeed: 5,         // Low threshold to turn
-  grip: 0.85,              // Good grip, but can drift
-  driftThreshold: 0.7,     // Start drifting at 70% max speed in corners
-  driftFactor: 0.15,       // Gentle drift
+  grip: 0.95,              // Higher grip for better control (was 0.85)
+  driftThreshold: 0.85,    // Higher threshold before drift (was 0.7)
+  driftFactor: 0.08,       // Less slidey when drifting (was 0.15)
+  length: 40,              // Car length for collision
+  width: 20,               // Car width for collision
 };
 
 // ============================================

--- a/src/tracks/types.ts
+++ b/src/tracks/types.ts
@@ -120,6 +120,14 @@ export interface TrackPathPoint {
 }
 
 /**
+ * Racing line strategy type.
+ * - optimal: Standard fastest line, cuts corners
+ * - overtaking: Wider entry, late apex for better exit speed
+ * - defensive: Inside line, blocks overtaking attempts
+ */
+export type RacingLineType = 'optimal' | 'overtaking' | 'defensive';
+
+/**
  * Racing line point - the optimal path around the track.
  */
 export interface RacingLinePoint {
@@ -154,8 +162,11 @@ export interface ComputedTrack {
   /** Track centerline path points */
   path: TrackPathPoint[];
   
-  /** Racing line points */
+  /** Racing line points (default optimal line, for backward compat) */
   racingLine: RacingLinePoint[];
+  
+  /** All racing line variants by type */
+  racingLines: Record<RacingLineType, RacingLinePoint[]>;
   
   /** Track boundary points (outer edge) */
   outerBoundary: Point[];

--- a/tests/unit/physics/PhysicsPlugin.test.ts
+++ b/tests/unit/physics/PhysicsPlugin.test.ts
@@ -121,10 +121,12 @@ describe('PhysicsPlugin', () => {
       physicsPlugin.setTrackBoundaries(trackPath);
       
       // Register car on track (within width/2 = 25 of centerline at y=100)
-      physicsPlugin.registerCar('onTrack', 100, 110, 0);
+      // Place at x=50 to be far from the off-track car
+      physicsPlugin.registerCar('onTrack', 50, 110, 0);
       
       // Register car off track (more than 25 away from centerline)
-      physicsPlugin.registerCar('offTrack', 100, 150, 0, undefined, true);
+      // Place at x=150 to be far from the on-track car (avoid car-car collision)
+      physicsPlugin.registerCar('offTrack', 150, 150, 0, undefined, true);
       
       // Simulate frame update
       pluginManager.updateAll(1/60);


### PR DESCRIPTION
## Summary
- Adds car-to-car collision resolution
- Doubles car speed/acceleration for faster racing feel
- Widens all tracks for better racing room
- Adds racing line type definitions for future AI strategies

## Changes

### Car Physics (`src/physics/types.ts`)
- `maxSpeed`: 180 → 360
- `acceleration`: 120 → 240
- `braking`: 200 → 400
- `turnSpeed`: 3.0 → 4.5 (more responsive at high speed)
- `grip`: 0.85 → 0.95 (better control)
- Added `length` and `width` properties for collision detection

### Collision System (`src/physics/PhysicsPlugin.ts`)
- Calls `resolveAllCarCollisions()` each frame when multiple cars exist
- Prevents cars from overlapping

### Track Widths
- Bergheim: 60 → 90
- Porto Azzurro: 55 → 70
- Velocita: 70 → 100

### Racing Line Types (`src/tracks/types.ts`)
- Added `RacingLineType`: 'optimal' | 'overtaking' | 'defensive'
- Added `racingLines` property to `ComputedTrack` for multiple line strategies

### Tests
- Updated physics tests to account for collision system